### PR TITLE
Fix Putting Items In Part Replacer

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -179,6 +179,7 @@
 		numbered_contents = list()
 		adjusted_contents = 0
 		for(var/obj/item/I in contents)
+			I.screen_loc = null // Reset so standard_orient_objs starts with a clean slate
 			var/found = 0
 			for(var/datum/numbered_display/ND in numbered_contents)
 				if(ND.sample_object.type == I.type)


### PR DESCRIPTION
Fixes #56 - Issue was that the screen_loc was never being cleared on the
items when they are put into the part replacer, so they continue to be
rendered where they were.
